### PR TITLE
Allow query filtering

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -73,7 +73,8 @@ function MapboxInspect(options) {
     assignLayerColor: colors.brightColor,
     buildInspectStyle: stylegen.generateInspectStyle,
     renderPopup: renderPopup,
-    popup: popup
+    popup: popup,
+    queryParameters: {}
   }, options);
 
   this.sources = {};
@@ -148,15 +149,18 @@ MapboxInspect.prototype._onMousemove = function (e) {
   if (!this.options.showInspectMapPopup && this._showInspectMap) return;
   if (!this.options.showMapPopup && !this._showInspectMap) return;
 
-  var features = this._map.queryRenderedFeatures(e.point);
+  var features = this._map.queryRenderedFeatures(e.point, this.options.queryParameters);
+
   this._map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
 
-  if (!features.length && this._popup) {
-    this._popup.remove();
-  } else if (this._popup) {
-    this._popup.setLngLat(e.lngLat)
-      .setHTML(this.options.renderPopup(features))
-      .addTo(this._map);
+  if (this._popup) {
+    if (!features.length) {
+      this._popup.remove();
+    } else {
+      this._popup.setLngLat(e.lngLat)
+        .setHTML(this.options.renderPopup(features))
+        .addTo(this._map);
+    }
   }
 };
 


### PR DESCRIPTION
Allow passing a `queryParameters` object, structured like the parameters object documented for [`map.queryRenderedFeatures`](https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures)

For example, this lets you show the inspect popup for only certain layers: 

```js
map.addControl(new MapboxInspect({
        queryParameters: {
            layers: ['composite_road_line']
        }
}));
```

or use custom layer [filtering](https://www.mapbox.com/mapbox-gl-style-spec/#types-filter): 

```js
map.addControl(new MapboxInspect({
        queryParameters: {
            filter: ['>', 'height', 10]
        } 
}));
```
