### PR TITLE
Optional buffer around pointer

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -73,7 +73,8 @@ function MapboxInspect(options) {
     assignLayerColor: colors.brightColor,
     buildInspectStyle: stylegen.generateInspectStyle,
     renderPopup: renderPopup,
-    popup: popup
+    popup: popup,
+    selectThreshold: 5
   }, options);
 
   this.sources = {};
@@ -148,7 +149,26 @@ MapboxInspect.prototype._onMousemove = function (e) {
   if (!this.options.showInspectMapPopup && this._showInspectMap) return;
   if (!this.options.showMapPopup && !this._showInspectMap) return;
 
-  var features = this._map.queryRenderedFeatures(e.point);
+
+
+  var queryBox;
+  if (this.options.selectThreshold === 0) {
+    queryBox = e.point;
+  } else {
+    // set a bbox around the pointer
+    queryBox = [
+      [
+        e.point.x - this.options.selectThreshold,
+        e.point.y + this.options.selectThreshold
+      ], // bottom left (SW)
+      [
+        e.point.x + this.options.selectThreshold,
+        e.point.y - this.options.selectThreshold
+      ] // top right (NE)
+    ];
+  }
+
+  var features = this._map.queryRenderedFeatures(queryBox);
   this._map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
 
   if (!features.length && this._popup) {


### PR DESCRIPTION
I find that inspecting roads can be a little bit fiddly since they're thin lines. This adds a parameter so you can optionally set a custom pixel buffer around the pointer when querying for features to make inspection a bit more forgiving

```js
map.addControl(new MapboxInspect({
        selectThreshold: 50
});
```