### PR TITLE
optionally disable inspect style

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -74,8 +74,9 @@ function MapboxInspect(options) {
     buildInspectStyle: stylegen.generateInspectStyle,
     renderPopup: renderPopup,
     popup: popup,
-    selectThreshold: 5
-    queryParameters: {}
+    selectThreshold: 5,
+    queryParameters: {},
+    useInspectStyle: true
   }, options);
 
   this.sources = {};
@@ -108,11 +109,15 @@ MapboxInspect.prototype._inspectStyle = function () {
 
 MapboxInspect.prototype.render = function () {
   if (this._showInspectMap) {
-    this._map.setStyle(fixStyle(markInspectStyle(this._inspectStyle())));
+    if (this.options.useInspectStyle) {
+      this._map.setStyle(fixStyle(markInspectStyle(this._inspectStyle())));
+    }
     this._toggle.setMapIcon();
   } else if (this._originalStyle) {
     if (this._popup) this._popup.remove();
-    this._map.setStyle(fixStyle(this._originalStyle));
+    if (this.options.useInspectStyle) {
+      this._map.setStyle(fixStyle(this._originalStyle));
+    }
     this._toggle.setInspectIcon();
   }
 };
@@ -149,7 +154,7 @@ MapboxInspect.prototype._onStyleChange = function () {
 MapboxInspect.prototype._onMousemove = function (e) {
   if (!this.options.showInspectMapPopup && this._showInspectMap) return;
   if (!this.options.showMapPopup && !this._showInspectMap) return;
-  
+
   var queryBox;
   if (this.options.selectThreshold === 0) {
     queryBox = e.point;


### PR DESCRIPTION
Lets you leave your map with it's own style if you want to just have a hovering inspect popup automatically without the x-ray-esque style