### PR TITLE
Allow any Mapbox GL JS version above 0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "watchify": "^3.8.0"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.29.0 || ^0.30.0 || ^0.31.0 || ^0.32.0 || ^0.33.0 || ^0.34.0"
+    "mapbox-gl": ">0.28.0"
   },
   "eslintConfig": {
     "parserOptions": {


### PR DESCRIPTION
Allow all future versions of GL JS, fixes failing tests I'm hitting and is a bit more future proof.

@lukasmartinelli - What do you think?