### PR TITLE
Support for htmlNodes (Nodes) in popups

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -187,9 +187,17 @@ MapboxInspect.prototype._onMousemove = function (e) {
     if (!features.length) {
       this._popup.remove();
     } else {
-      this._popup.setLngLat(e.lngLat)
-        .setHTML(this.options.renderPopup(features))
-        .addTo(this._map);
+      this._popup.setLngLat(e.lngLat);
+
+      var type = typeof this.options.renderPopup(features);
+
+      if (type === 'string') {
+        this._popup.setHTML(this.options.renderPopup(features));
+      } else {
+        this._popup.setDOMContent(this.options.renderPopup(features));
+      }
+
+      this._popup.addTo(this._map);
     }
   }
 };


### PR DESCRIPTION
I believe that this pull request doesn't change anything for the current users of mapbox-gl-inspect.

I created this pull request because I work on https://github.com/maputnik/editor/issues/60. I need to have access in React to events inside a popup (to handle onClick). It looks like I can't have it when mapbox-gl-inspect uses the setHTML method so I added a basic support for the setDOMContent method.

Links you may want to see before merging this pull request:

https://www.mapbox.com/mapbox-gl-js/api/#popup#sethtml

https://www.mapbox.com/mapbox-gl-js/api/#popup#setdomcontent

Enjoy the rest of your day, Lukas! :)