### PR TITLE
Fix source change handling

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -128,6 +128,8 @@ MapboxInspect.prototype.render = function () {
 MapboxInspect.prototype._onSourceChange = function () {
   var sources = this.sources;
   var map = this._map;
+  var mapStyle = map.getStyle();
+  var mapStyleSourcesNames = Object.keys(mapStyle.sources);
   var previousSources = Object.assign({}, sources);
 
   //NOTE: This heavily depends on the internal API of Mapbox GL
@@ -142,7 +144,13 @@ MapboxInspect.prototype._onSourceChange = function () {
     }
   });
 
-  if (!isEqual(previousSources, sources)) {
+  Object.keys(sources).forEach(function (sourceId) {
+    if (mapStyleSourcesNames.indexOf(sourceId) === -1) {
+      delete sources[sourceId];
+    }
+  });
+
+  if (!isEqual(previousSources, sources) && Object.keys(sources).length > 0) {
     this.render();
   }
 };


### PR DESCRIPTION
English is not my primary language so don't hesitate to ask clarifying questions. :)

This code is related to the https://github.com/maputnik/editor/issues/95 issue.

@orangemug suggested to me that the problem might be solved inside [lukasmartinelli/mapbox-gl-inspect](https://github.com/lukasmartinelli/mapbox-gl-inspect) and I believe he is correct.

Two problems I noticed in the code of `mapbox-gl-inspect`:

* * *

**1. `mapbox-gl-inspect` aggregates sources used in the styles of maps**

When I use one style based on `openmaptiles` and then switch to `mapbox`-based style, `mapbox-gl-inspect` keeps both sources in the memory. This and https://github.com/lukasmartinelli/mapbox-gl-inspect/blob/master/lib/MapboxInspect.js#L107 raises the problem of https://github.com/maputnik/editor/issues/95. `stylegen` generates colored layers from all sources ever used by the user in one session. They are generated properly, but can’t be displayed correctly if not all sources are available in the current map style.

* * *

**2. `mapbox-gl-inspect` behaves badly when you try to clear the list of sources**

When `this.sources` is not empty and you will try to clear it, it’s going to work for a split second. Then https://github.com/lukasmartinelli/mapbox-gl-inspect/blob/master/lib/MapboxInspect.js#L146 is being executed and `MapboxInspect.prototype._onSourceChange` gets invoked one more time with `this.sources` in the latest non–empty state. Skipping re–render in empty sources list scenario solves the problem.

* * *

This bug fix removes problem reported in the https://github.com/maputnik/editor/issues/95 issue.