### PR TITLE
Allow to block the display of the popup when hovering a feature

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -77,6 +77,7 @@ function MapboxInspect(options) {
     showMapPopup: false,
     showMapPopupOnHover: true,
     showInspectMapPopupOnHover: true,
+    blockHoverPopupOnClick: false,
     backgroundColor: '#fff',
     assignLayerColor: colors.brightColor,
     buildInspectStyle: stylegen.generateInspectStyle,
@@ -92,6 +93,7 @@ function MapboxInspect(options) {
   this.assignLayerColor = this.options.assignLayerColor;
   this.toggleInspector = this.toggleInspector.bind(this);
   this._popup = this.options.popup;
+  this._popupBlocked = false;
   this._showInspectMap = this.options.showInspectMap;
   this._onSourceChange = this._onSourceChange.bind(this);
   this._onMousemove = this._onMousemove.bind(this);
@@ -192,12 +194,18 @@ MapboxInspect.prototype._onMousemove = function (e) {
   if (this._showInspectMap) {
     if (!this.options.showInspectMapPopup) return;
     if (e.type === 'mousemove' && !this.options.showInspectMapPopupOnHover) return;
+    if (e.type === 'click' && this.options.showInspectMapPopupOnHover && this.options.blockHoverPopupOnClick) {
+      this._popupBlocked = !this._popupBlocked;
+    }
   } else {
     if (!this.options.showMapPopup) return;
     if (e.type === 'mousemove' && !this.options.showMapPopupOnHover) return;
+    if (e.type === 'click' && this.options.showMapPopupOnHover && this.options.blockHoverPopupOnClick) {
+      this._popupBlocked = !this._popupBlocked;
+    }
   }
 
-  if (this._popup) {
+  if (!this._popupBlocked && this._popup) {
     if (!features.length) {
       this._popup.remove();
     } else {


### PR DESCRIPTION
I propose a small change in the inspect behavior in hover mode.

When we inspect data in hover mode  we would like to be able to stop the hovering temporary to select/copy the content of the popup.

This PR allows to stop the hovering after clicking on a feature then reactivate it  after another click. 

```js
map.addControl(new MapboxInspect({
  showInspectMap: true,
  showInspectButton: false,
  showInspectMapPopupOnHover: true,
  blockHoverPopupOnClick: true
});
```
