### PR TITLE
Avoid calling popup render each time twice

### DIFF
--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -211,12 +211,12 @@ MapboxInspect.prototype._onMousemove = function (e) {
     } else {
       this._popup.setLngLat(e.lngLat);
 
-      var type = typeof this.options.renderPopup(features);
+      var renderedPopup = this.options.renderPopup(features);
 
-      if (type === 'string') {
-        this._popup.setHTML(this.options.renderPopup(features));
+      if (typeof renderPopup === 'string') {
+        this._popup.setHTML(renderedPopup);
       } else {
-        this._popup.setDOMContent(this.options.renderPopup(features));
+        this._popup.setDOMContent(renderedPopup);
       }
 
       this._popup.addTo(this._map);


### PR DESCRIPTION
When one creates a custom `renderPopup` method, it was always called twice for each display.

These small changes avoid this extraneous call.