### PR TITLE
Add support for image/video layers

### DIFF
--- a/examples/custom-color-1.html
+++ b/examples/custom-color-1.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.33.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.33.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/custom-color-2.html
+++ b/examples/custom-color-2.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/custom-popup.html
+++ b/examples/custom-popup.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/geojson-source.html
+++ b/examples/geojson-source.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/image-source-no-inspect-style.html
+++ b/examples/image-source-no-inspect-style.html
@@ -17,16 +17,42 @@
 
 <div id='map'></div>
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoibW9yZ2Vua2FmZmVlIiwiYSI6IjIzcmN0NlkifQ.0LRTNgCc-envt9d5MzR75w';
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/mapbox/bright-v9',
-    center: [-74.50, 40],
-    zoom: 3,
+    style: {
+      "version": 8,
+      "zoom": 5,
+      "center": [-75.789, 41.874],
+      "bearing": 0,
+      "pitch": 0,
+      "sources": {
+        'overlay': {
+          'type': 'image',
+          'url': 'https://docs.mapbox.com/mapbox-gl-js/assets/radar.gif',
+          'coordinates': [
+            [-80.425, 46.437],
+            [-71.516, 46.437],
+            [-71.516, 37.936],
+            [-80.425, 37.936]
+          ]
+        }
+      },
+      "layers": [
+        {
+          'id': 'overlay',
+          'source': 'overlay',
+          'type': 'raster'
+        }
+      ]
+    },
     hash: true
 });
 map.addControl(new mapboxgl.NavigationControl());
-map.addControl(new MapboxInspect());
+map.addControl(new MapboxInspect({
+  showInspectButton: false,
+  showMapPopup: true
+}));
+
 </script>
 
 </body>

--- a/examples/image-source.html
+++ b/examples/image-source.html
@@ -17,16 +17,39 @@
 
 <div id='map'></div>
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoibW9yZ2Vua2FmZmVlIiwiYSI6IjIzcmN0NlkifQ.0LRTNgCc-envt9d5MzR75w';
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/mapbox/bright-v9',
-    center: [-74.50, 40],
-    zoom: 3,
+    style: {
+      "version": 8,
+      "zoom": 5,
+      "center": [-75.789, 41.874],
+      "bearing": 0,
+      "pitch": 0,
+      "sources": {
+        'overlay': {
+          'type': 'image',
+          'url': 'https://docs.mapbox.com/mapbox-gl-js/assets/radar.gif',
+          'coordinates': [
+            [-80.425, 46.437],
+            [-71.516, 46.437],
+            [-71.516, 37.936],
+            [-80.425, 37.936]
+          ]
+        }
+      },
+      "layers": [
+        {
+          'id': 'overlay',
+          'source': 'overlay',
+          'type': 'raster'
+        }
+      ]
+    },
     hash: true
 });
 map.addControl(new mapboxgl.NavigationControl());
 map.addControl(new MapboxInspect());
+
 </script>
 
 </body>

--- a/examples/inspect-only.html
+++ b/examples/inspect-only.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/less-fidly.html
+++ b/examples/less-fidly.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/many-sources.html
+++ b/examples/many-sources.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/map-popup.html
+++ b/examples/map-popup.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/no-inspect-style.html
+++ b/examples/no-inspect-style.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/no-popup.html
+++ b/examples/no-popup.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/old-mapbox-gl.html
+++ b/examples/old-mapbox-gl.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.28.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.28.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/osm-liberty.html
+++ b/examples/osm-liberty.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/popup-on-click.html
+++ b/examples/popup-on-click.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/query-params.html
+++ b/examples/query-params.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='/dist/mapbox-gl-inspect.js'></script>
     <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/examples/video-source-no-inspect-style.html
+++ b/examples/video-source-no-inspect-style.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Mapbox GL Inspect</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <!-- 1.8.0 because 0.40.1 doesn't play videos correctly -->
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.8.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.8.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='/dist/mapbox-gl-inspect.js'></script>
+    <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: {
+      "version": 8,
+      "center": [-122.514426, 37.562984],
+      "zoom": 17,
+      "bearing": 0,
+      "pitch": 0,
+      "sources": {
+        'video': {
+          'type': 'video',
+          'urls': [
+            'https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4',
+            'https://static-assets.mapbox.com/mapbox-gl-js/drone.webm'
+          ],
+          'coordinates': [
+            [-122.51596391201019, 37.56238816766053],
+            [-122.51467645168304, 37.56410183312965],
+            [-122.51309394836426, 37.563391708549425],
+            [-122.51423120498657, 37.56161849366671]
+          ]
+        }
+      },
+      "layers": [
+        {
+          'id': 'video',
+          'type': 'raster',
+          'source': 'video'
+        }
+      ]
+    },
+    hash: true
+});
+map.addControl(new mapboxgl.NavigationControl());
+map.addControl(new MapboxInspect({
+  showInspectButton: false,
+  showMapPopup: true
+}));
+
+</script>
+
+</body>
+</html>

--- a/examples/video-source.html
+++ b/examples/video-source.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Mapbox GL Inspect</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <!-- 1.8.0 because 0.40.1 doesn't play videos correctly -->
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.8.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.8.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='/dist/mapbox-gl-inspect.js'></script>
+    <link href='/dist/mapbox-gl-inspect.css' rel='stylesheet' />
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: {
+      "version": 8,
+      "center": [-122.514426, 37.562984],
+      "zoom": 17,
+      "bearing": 0,
+      "pitch": 0,
+      "sources": {
+        'video': {
+          'type': 'video',
+          'urls': [
+            'https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4',
+            'https://static-assets.mapbox.com/mapbox-gl-js/drone.webm'
+          ],
+          'coordinates': [
+            [-122.51596391201019, 37.56238816766053],
+            [-122.51467645168304, 37.56410183312965],
+            [-122.51309394836426, 37.563391708549425],
+            [-122.51423120498657, 37.56161849366671]
+          ]
+        }
+      },
+      "layers": [
+        {
+          'id': 'video',
+          'type': 'raster',
+          'source': 'video'
+        }
+      ]
+    },
+    hash: true
+});
+map.addControl(new mapboxgl.NavigationControl());
+map.addControl(new MapboxInspect());
+
+</script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Inspect</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.31.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
     <script src='dist/mapbox-gl-inspect.min.js'></script>
     <link href='dist/mapbox-gl-inspect.css' rel='stylesheet' />
     <style>

--- a/lib/MapboxInspect.js
+++ b/lib/MapboxInspect.js
@@ -9,11 +9,19 @@ function isInspectStyle(style) {
 }
 
 function markInspectStyle(style) {
-  return Object.assign(style, {
-    metadata: Object.assign({}, style.metadata, {
-      'mapbox-gl-inspect:inspect': true
-    })
-  });
+  return Object.assign(
+    {},
+    style,
+    {
+      metadata: Object.assign(
+        {},
+        style.metadata,
+        {
+          'mapbox-gl-inspect:inspect': true
+        }
+      )
+    }
+  );
 }
 
 function fixRasterSource(source) {
@@ -113,21 +121,42 @@ MapboxInspect.prototype.toggleInspector = function () {
 
 MapboxInspect.prototype._inspectStyle = function () {
   var coloredLayers = stylegen.generateColoredLayers(this.sources, this.assignLayerColor);
-  return this.options.buildInspectStyle(this._map.getStyle(), coloredLayers, {
+  return this.options.buildInspectStyle(this._originalStyle, coloredLayers, {
     backgroundColor: this.options.backgroundColor
   });
+};
+
+MapboxInspect.prototype._nonInspectStyle = function (style) {
+  const nonInspectStyle = stylegen.generateNormalStyle(style);
+  return Object.assign(
+    {}, 
+    style,
+    {
+      sources: Object.assign(
+        {},
+        style.sources,
+        nonInspectStyle.sources,
+      ),
+      layers: [].concat(
+        style.layers,
+        nonInspectStyle.layers,
+      )
+    }
+  );
 };
 
 MapboxInspect.prototype.render = function () {
   if (this._showInspectMap) {
     if (this.options.useInspectStyle) {
-      this._map.setStyle(fixStyle(markInspectStyle(this._inspectStyle())));
+      var newStyle = fixStyle(markInspectStyle(this._inspectStyle()))
+      this._map.setStyle(newStyle);
     }
     this._toggle.setMapIcon();
   } else if (this._originalStyle) {
     if (this._popup) this._popup.remove();
     if (this.options.useInspectStyle) {
-      this._map.setStyle(fixStyle(this._originalStyle));
+      var newStyle = fixStyle(this._nonInspectStyle(this._originalStyle));
+      this._map.setStyle(newStyle);
     }
     this._toggle.setInspectIcon();
   }
@@ -137,6 +166,7 @@ MapboxInspect.prototype._onSourceChange = function () {
   var sources = this.sources;
   var map = this._map;
   var mapStyle = map.getStyle();
+
   var mapStyleSourcesNames = Object.keys(mapStyle.sources);
   var previousSources = Object.assign({}, sources);
 
@@ -147,7 +177,7 @@ MapboxInspect.prototype._onSourceChange = function () {
     var layerIds = sourceCache._source.vectorLayerIds;
     if (layerIds) {
       sources[sourceId] = layerIds;
-    } else if (sourceCache._source.type === 'geojson') {
+    } else if (['geojson', 'image', 'video'].indexOf(sourceCache._source.type) > -1) {
       sources[sourceId] = [];
     }
   });
@@ -163,10 +193,21 @@ MapboxInspect.prototype._onSourceChange = function () {
   }
 };
 
+function withoutSpecialLayers (style) {
+  var layers = style.layers.filter(function (layer) {
+    return !layer.id.match(/^__mapbox-gl-inspect:/);
+  })
+  return Object.assign(
+    {},
+    style,
+    {layers},
+  );
+}
+
 MapboxInspect.prototype._onStyleChange = function () {
   var style = this._map.getStyle();
   if (!isInspectStyle(style)) {
-    this._originalStyle = style;
+    this._originalStyle = withoutSpecialLayers(style);
   }
 };
 
@@ -213,7 +254,7 @@ MapboxInspect.prototype._onMousemove = function (e) {
 
       var renderedPopup = this.options.renderPopup(features);
 
-      if (typeof renderPopup === 'string') {
+      if (typeof renderedPopup === 'string') {
         this._popup.setHTML(renderedPopup);
       } else {
         this._popup.setDOMContent(renderedPopup);

--- a/lib/renderPopup.js
+++ b/lib/renderPopup.js
@@ -14,15 +14,39 @@ function renderProperty(propertyName, property) {
     '</div>';
 }
 
+function removePrefixes (val) {
+  return val.replace(/^__mapbox-gl-inspect:/, "");
+}
+
 function renderLayer(layerId) {
-  return '<div class="mapbox-gl-inspect_layer">' + layerId + '</div>';
+  return '<div class="mapbox-gl-inspect_layer">' + removePrefixes(layerId) + '</div>';
 }
 
 function renderProperties(feature) {
   var sourceProperty = renderLayer(feature.layer['source-layer'] || feature.layer.source);
-  var typeProperty = renderProperty('$type', feature.geometry.type);
+
+  var typeProperty;
+  if (
+    feature.properties &&
+    feature.properties['mapbox-gl-inspect:source']
+  ) {
+    var origSource = feature.properties['mapbox-gl-inspect:source'];
+    if (typeof(origSource) === "string") {
+      origSource = JSON.parse(origSource);
+    }
+    typeProperty = renderProperty(
+      '$type',
+      origSource.type
+    );
+  }
+  else {
+    typeProperty = renderProperty('$type', feature.geometry.type);
+  }
   var properties = Object.keys(feature.properties).map(function (propertyName) {
-    return renderProperty(propertyName, feature.properties[propertyName]);
+    // Ignore properties set by this library.
+    if (!propertyName.match(/^mapbox-gl-inspect:/)) {
+      return renderProperty(propertyName, feature.properties[propertyName]);
+    }
   });
   return [sourceProperty, typeProperty].concat(properties).join('');
 }

--- a/lib/stylegen.js
+++ b/lib/stylegen.js
@@ -1,6 +1,8 @@
+const KEY = "__mapbox-gl-inspect:";
+
 function circleLayer(color, source, vectorLayer) {
   var layer = {
-    id: [source, vectorLayer, 'circle'].join('_'),
+    id: [KEY, source, vectorLayer, 'circle'].join('_'),
     source: source,
     type: 'circle',
     paint: {
@@ -17,7 +19,7 @@ function circleLayer(color, source, vectorLayer) {
 
 function polygonLayer(color, outlineColor, source, vectorLayer) {
   var layer = {
-    id: [source, vectorLayer, 'polygon'].join('_'),
+    id: [KEY, source, vectorLayer, 'polygon'].join('_'),
     source: source,
     type: 'fill',
     paint: {
@@ -35,7 +37,7 @@ function polygonLayer(color, outlineColor, source, vectorLayer) {
 
 function lineLayer(color, source, vectorLayer) {
   var layer = {
-    id: [source, vectorLayer, 'line'].join('_'),
+    id: [KEY, source, vectorLayer, 'line'].join('_'),
     source: source,
     layout: {
       'line-join': 'round',
@@ -99,8 +101,63 @@ function generateColoredLayers(sources, assignLayerColor) {
   return polyLayers.concat(lineLayers).concat(circleLayers);
 }
 
+function generateNormalStyle(originalMapStyle, opts) {
+  var invisibleLayers = [];
+
+  var sources = {};
+  Object.keys(originalMapStyle.sources).forEach(function (sourceId) {
+    var source = originalMapStyle.sources[sourceId];
+    if (
+      ['video', 'image'].indexOf(source.type) > -1 &&
+      source.coordinates.length === 4
+    ) {
+      var oc = source.coordinates;
+      sources["__mapbox-gl-inspect:"+sourceId] = {
+        'type': 'geojson',
+        'data': {
+          'type': 'Feature',
+          'properties': {
+            // Store the original source for use by inspector
+            "mapbox-gl-inspect:source": source
+          },
+          'geometry': {
+            'type': 'Polygon',
+            'coordinates': [
+              [
+                source.coordinates[0],
+                source.coordinates[1],
+                source.coordinates[2],
+                source.coordinates[3],
+                source.coordinates[0],
+              ]
+            ],
+          }
+        }
+      };
+
+      invisibleLayers.push({
+        id: ["__mapbox-gl-inspect:", sourceId, 'polygon'].join('_'),
+        source: "__mapbox-gl-inspect:"+sourceId,
+        type: 'fill',
+        paint: {
+          'fill-color': "rgba(0,0,0,0)",
+        },
+        filter: ['==', '$type', 'Polygon']
+      })
+    }
+  });
+
+  return Object.assign({},
+    originalMapStyle,
+    {
+      layers: invisibleLayers,
+      sources: sources
+    }
+  );
+}
+
 /**
- * Create inspection style out of the original style and the new colored layers
+ * Create inspection style out of the original style and the new colored layera
  * @param {Object} Original map styles
  * @param {array} Array of colored Mapbox GL layers
  * @return {Object} Colored inspect style
@@ -124,12 +181,44 @@ function generateInspectStyle(originalMapStyle, coloredLayers, opts) {
     if (source.type === 'vector' || source.type === 'geojson') {
       sources[sourceId] = source;
     }
+    if (
+      ['video', 'image'].indexOf(source.type) > -1 &&
+      source.coordinates.length === 4
+    ) {
+      var oc = source.coordinates;
+      sources[sourceId] = {
+        'type': 'geojson',
+        'data': {
+          'type': 'Feature',
+          'properties': {
+            // Store the original source for use by inspector
+            "mapbox-gl-inspect:source": source
+          },
+          'geometry': {
+            'type': 'Polygon',
+            'coordinates': [
+              [
+                source.coordinates[0],
+                source.coordinates[1],
+                source.coordinates[2],
+                source.coordinates[3],
+                source.coordinates[0],
+              ]
+            ],
+          }
+        }
+      };
+    }
   });
 
-  return Object.assign(originalMapStyle, {
-    layers: [backgroundLayer].concat(coloredLayers),
-    soources: sources
-  });
+  return Object.assign(
+    {},
+    originalMapStyle,
+    {
+      layers: [backgroundLayer].concat(coloredLayers),
+      sources: sources
+    }
+  );
 }
 
 exports.polygonLayer = polygonLayer;
@@ -137,3 +226,4 @@ exports.lineLayer = lineLayer;
 exports.circleLayer = circleLayer;
 exports.generateInspectStyle = generateInspectStyle;
 exports.generateColoredLayers = generateColoredLayers;
+exports.generateNormalStyle = generateNormalStyle;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "watchify": "^3.8.0"
   },
   "peerDependencies": {
-    "mapbox-gl": ">0.28.0"
+    "mapbox-gl": ">=0.40.1"
   },
   "eslintConfig": {
     "parserOptions": {


### PR DESCRIPTION
Adding support for image/video sources via adding additional polygons with their coordinates.

Also

 - Updated minimum support to `v0.40.1` because of bugs with `image` sources in previous versions
 - Fixes some object mutation issues
 - Adds four image/video examples

Demo
![localhost_8000_examples_image-source html (2)](https://user-images.githubusercontent.com/235915/77253795-be101880-6c54-11ea-9643-a9a40ea8eed2.png)
![localhost_8000_examples_video-source html](https://user-images.githubusercontent.com/235915/77253800-c2d4cc80-6c54-11ea-9298-ede84eb7b0e8.png)
